### PR TITLE
Speed up similarity computation and clean up the output.

### DIFF
--- a/commons.py
+++ b/commons.py
@@ -15,10 +15,8 @@ def get_model_and_optimizer(args, logger):
     model = fpn.PanopticFPN(args)
     model = nn.DataParallel(model)
     model = model.cuda()
-
-    # Init classifier (for eval only.)
-    classifier = initialize_classifier(args)
-
+    # Init centroids.
+    centroids = torch.normal(0, 0.01, size=(args.K_train, args.in_dim), requires_grad=False).cuda()
     # Init optimizer 
     if args.optim_type == 'SGD':
         logger.info('SGD optimizer is used.')
@@ -27,6 +25,8 @@ def get_model_and_optimizer(args, logger):
     elif args.optim_type == 'Adam':
         logger.info('Adam optimizer is used.')
         optimizer = torch.optim.Adam(filter(lambda x: x.requires_grad, model.module.parameters()), lr=args.lr)
+    else:
+        raise ValueError('Unknown optimizer type.')
 
     # optional restart. 
     args.start_epoch  = 0 
@@ -39,13 +39,13 @@ def get_model_and_optimizer(args, logger):
             args.start_epoch = checkpoint['epoch']
 
             model.load_state_dict(checkpoint['state_dict'])
-            classifier.load_state_dict(checkpoint['classifier1_state_dict'])
+            centroids = torch.load(checkpoint['centriods1'])
             optimizer.load_state_dict(checkpoint['optimizer'])
             logger.info('Loaded checkpoint. [epoch {}]'.format(args.start_epoch))
         else:
             logger.info('No checkpoint found at [{}].\nStart from beginning...\n'.format(load_path))
     
-    return model, optimizer, classifier
+    return model, optimizer, centroids
 
 
 
@@ -179,17 +179,17 @@ def compute_labels(args, logger, dataloader, model, centroids, view):
 
             if (i % 200) == 0:
                 logger.info('[Assigning labels] {} / {}'.format(i, len(dataloader)))
+    # Calculate the weight of each cluster, or label.
     weight = counts / counts.sum()
 
     return weight
 
 
-def evaluate(args, logger, dataloader, classifier, model):
+def evaluate(args, logger, dataloader, centroids, model):
     logger.info('====== METRIC TEST : {} ======\n'.format(args.metric_test))
     histogram = np.zeros((args.K_test, args.K_test))
 
     model.eval()
-    classifier.eval()
     with torch.no_grad():
         for i, (_, image, label) in enumerate(dataloader):
             image = image.cuda(non_blocking=True)
@@ -204,7 +204,7 @@ def evaluate(args, logger, dataloader, classifier, model):
                 logger.info('Batch label size   : {}'.format(list(label.shape)))
                 logger.info('Batch feature size : {}\n'.format(list(feats.shape)))
 
-            probs = classifier(feats)
+            probs = batch_similarity2D(feats, centroids)
             probs = F.interpolate(probs, label.shape[-2:], mode='bilinear', align_corners=False)
             preds = probs.topk(1, dim=1)[1].view(B, -1).cpu().numpy()
             label = label.view(B, -1).cpu().numpy()

--- a/commons.py
+++ b/commons.py
@@ -103,9 +103,8 @@ def run_mini_batch_kmeans(args, logger, dataloader, model, view):
                         kmeans_loss.update(D.mean())
                         logger.info('Initial k-means loss: {:.4f} '.format(kmeans_loss.avg))
                         
-                        # Compute counts for each cluster. 
-                        for k in np.unique(I):
-                            data_count[k] += len(np.where(I == k)[0])
+                        # Compute counts for each cluster.
+                        data_count += np.bincount(I.ravel().astype('int32'), minlength=args.K_train)
                         first_batch = False
                     else:
                         b_feat = torch.cat(featslist)
@@ -114,14 +113,16 @@ def run_mini_batch_kmeans(args, logger, dataloader, model, view):
 
                         kmeans_loss.update(D.mean())
 
-                        # Update centroids. 
-                        for k in np.unique(I):
-                            idx_k = np.where(I == k)[0]
-                            data_count[k] += len(idx_k)
-                            centroid_lr    = len(idx_k) / (data_count[k] + 1e-6)
-                            centroids[k]   = (1 - centroid_lr) * centroids[k] + centroid_lr * b_feat[idx_k].mean(0).numpy().astype('float32')
-                    
-                    # Empty. 
+                        # Update centroids.
+                        I = I.ravel()
+                        k_count = np.bincount(I.astype('int32'), minlength=args.K_train)
+                        data_count += k_count
+                        centroid_lr = (k_count / (data_count + 1e-6)).astype('float32')
+                        mean_feat = torch.stack([torch.mean(b_feat[I == k]) for k in range(args.K_train)])
+                        centroids = (1 - np.expand_dims(centroid_lr, 1)) * centroids + \
+                                    np.expand_dims(centroid_lr * mean_feat.numpy().astype('float32'), 1)
+
+                    # Empty.
                     featslist   = []
                     num_batches = args.num_init_batches - args.num_batches
 
@@ -146,7 +147,7 @@ def compute_labels(args, logger, dataloader, model, centroids, view):
     dataloader.dataset.view = view
 
     # Define metric function with conv layer. 
-    metric_function = get_metric_as_conv(centroids)
+    # metric_function = get_metric_as_conv(centroids)
 
     counts = torch.zeros(K, requires_grad=False).cpu()
     model.eval()
@@ -170,7 +171,7 @@ def compute_labels(args, logger, dataloader, model, centroids, view):
                 logger.info('Batch feature size : {}\n'.format(list(feats.shape)))
 
             # Compute distance and assign label. 
-            scores  = compute_negative_euclidean(feats, centroids, metric_function) 
+            scores  = compute_negative_euclidean(feats, centroids)
 
             # Save labels and count. 
             for idx, idx_img in enumerate(indice):
@@ -221,7 +222,7 @@ def evaluate(args, logger, dataloader, classifier, model):
 
     new_hist = np.zeros((args.K_test, args.K_test))
     for idx in range(args.K_test):
-        new_hist[m[idx, 1]] = histogram[idx]
+        new_hist[m[idx, 1]] = histogram[idx] # make the largest entry in the diagonal of new_hist.
     
     # NOTE: Now [new_hist] is re-ordered to 12 thing + 15 stuff classses. 
     res1 = get_result_metrics(new_hist)

--- a/data/coco_train_dataset.py
+++ b/data/coco_train_dataset.py
@@ -123,7 +123,7 @@ class TrainCOCO(data.Dataset):
             image = self.random_color_saturation[ver](index, image)
         if 'hue' in self.inv_list:
             image = self.random_color_hue[ver](index, image)
-        if 'gray' in self.inv_list:
+        if 'grey' in self.inv_list:
             image = self.random_gray_scale[ver](index, image)
         if 'blur' in self.inv_list:
             image = self.random_gaussian_blur[ver](index, image)
@@ -147,7 +147,7 @@ class TrainCOCO(data.Dataset):
         N = len(self.imdb)
         
         # Base transform.
-        self.transform_base = BaseTransform(self.res2)
+        self.transform_base = BaseTransform(self.res2) # scale to res2: by default is 640.
         
         # Transforms for invariance. 
         # Color jitter (4), gray scale, blur. 
@@ -157,7 +157,7 @@ class TrainCOCO(data.Dataset):
         self.random_color_hue        = [RandomColorHue(x=0.1, p=0.8, N=N) for _ in range(2)]      # Control this later (NOTE)
         self.random_gray_scale    = [RandomGrayScale(p=0.2, N=N) for _ in range(2)]
         self.random_gaussian_blur = [RandomGaussianBlur(sigma=[.1, 2.], p=0.5, N=N) for _ in range(2)]
-
+        # Transforms for equivariance.
         self.random_horizontal_flip = RandomHorizontalTensorFlip(N=N)
         self.random_vertical_flip   = RandomVerticalFlip(N=N)
         self.random_resized_crop    = RandomResizedCrop(N=N, res=self.res1, scale=self.scale)


### PR DESCRIPTION
The similarity between centroids and a batch of feature map can be simply computed by ```torch.einsum()``` instead of using a complex 1x1 convolution module.